### PR TITLE
Add `union_typep/1`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
-locals_without_parens = [union_type: 1]
+locals_without_parens = [union_type: 1, union_typep: 1]
 
 [
   line_length: 120,

--- a/.github/workflows/elixir-build.yml
+++ b/.github/workflows/elixir-build.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   build:
@@ -30,3 +30,6 @@ jobs:
           otp-version: ${{ matrix.otp }}
           build-flags: --all-warnings --warnings-as-errors
 
+      - name: Run tests
+        run: mix test --warnings-as-errors
+        shell: sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ erl_crash.dump
 /config/*.secret.exs
 .elixir_ls/
 priv/plts
+/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## [0.0.3] - 2024-XX-XX
+
+### Added
+
+- `UnionTypespec.union_typep/1` macro.

--- a/lib/union_typespec.ex
+++ b/lib/union_typespec.ex
@@ -29,6 +29,27 @@ defmodule UnionTypespec do
   end
 
   @doc """
+  Same as `union_type/1` but for a private type (`@typep`).
+
+  Example:
+
+    defmodule MyModule do
+      import UnionTypespec, only: [union_typep: 1]
+
+      @permissions [:view, :edit, :admin]
+      union_typep permission :: @permissions
+
+      @spec random_permission() :: permission()
+      defp random_permission, do: Enum.random(@permissions)
+    end
+  """
+  defmacro union_typep({:"::", _, [{name, _, _}, data]}) do
+    quote bind_quoted: [data: data, name: name] do
+      @typep unquote({name, [], Elixir}) :: unquote(UnionTypespec.union_type_ast(data))
+    end
+  end
+
+  @doc """
   Unquote on the right-hand side of `@type` if you prefer the explicitness of that syntax over the `union_type` macro.
 
   Example:

--- a/lib/union_typespec.ex
+++ b/lib/union_typespec.ex
@@ -3,6 +3,8 @@ defmodule UnionTypespec do
   A simple, tiny, compile time-only library for defining an Elixir `@type` whose values are one of a fixed set of options.
   """
 
+  @moduledoc since: "0.0.1"
+
   @doc """
   Transforms an enumerable (like a list of atoms) into an AST for use in a typespec.
 
@@ -12,40 +14,20 @@ defmodule UnionTypespec do
 
   Example:
 
-    defmodule MyModule do
-      import UnionTypespec, only: [union_type: 1]
+      defmodule MyModule do
+        import UnionTypespec, only: [union_type: 1]
 
-      @permissions [:view, :edit, :admin]
-      union_type permission :: @permissions
+        @permissions [:view, :edit, :admin]
+        union_type permission :: @permissions
 
-      @spec random_permission() :: permission()
-      def random_permission, do: Enum.random(@permissions)
-    end
+        @spec random_permission() :: permission()
+        def random_permission, do: Enum.random(@permissions)
+      end
   """
+  @doc since: "0.0.1"
   defmacro union_type({:"::", _, [{name, _, _}, data]}) do
     quote bind_quoted: [data: data, name: name] do
       @type unquote({name, [], Elixir}) :: unquote(UnionTypespec.union_type_ast(data))
-    end
-  end
-
-  @doc """
-  Same as `union_type/1` but for a private type (`@typep`).
-
-  Example:
-
-    defmodule MyModule do
-      import UnionTypespec, only: [union_typep: 1]
-
-      @permissions [:view, :edit, :admin]
-      union_typep permission :: @permissions
-
-      @spec random_permission() :: permission()
-      defp random_permission, do: Enum.random(@permissions)
-    end
-  """
-  defmacro union_typep({:"::", _, [{name, _, _}, data]}) do
-    quote bind_quoted: [data: data, name: name] do
-      @typep unquote({name, [], Elixir}) :: unquote(UnionTypespec.union_type_ast(data))
     end
   end
 
@@ -54,14 +36,37 @@ defmodule UnionTypespec do
 
   Example:
 
-    defmodule MyModule do
-      @permissions [:view, :edit, :admin]
-      @type permission :: unquote(UnionTypespec.union_type_ast(@permissions))
+      defmodule MyModule do
+        @permissions [:view, :edit, :admin]
+        @type permission :: unquote(UnionTypespec.union_type_ast(@permissions))
 
-      @spec random_permission() :: permission()
-      def random_permission, do: Enum.random(@permissions)
-    end
+        @spec random_permission() :: permission()
+        def random_permission, do: Enum.random(@permissions)
+      end
   """
+  @doc since: "0.0.1"
   def union_type_ast([item]), do: item
   def union_type_ast([head | tail]), do: {:|, [], [head, union_type_ast(tail)]}
+
+  @doc """
+  Same as `#{inspect(__MODULE__)}.union_type/1` but for a private type (`@typep`).
+
+  Example:
+
+      defmodule MyModule do
+        import UnionTypespec, only: [union_typep: 1]
+
+        @permissions [:view, :edit, :admin]
+        union_typep permission :: @permissions
+
+        @spec random_permission() :: permission()
+        defp random_permission, do: Enum.random(@permissions)
+      end
+  """
+  @doc since: "0.0.3"
+  defmacro union_typep({:"::", _, [{name, _, _}, data]}) do
+    quote bind_quoted: [data: data, name: name] do
+      @typep unquote({name, [], Elixir}) :: unquote(UnionTypespec.union_type_ast(data))
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule UnionTypespec.MixProject do
       aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
       elixirc_paths: elixirc_paths(Mix.env()),
+      docs: docs(),
       preferred_cli_env: [
         check: :test,
         coveralls: :test,
@@ -71,6 +72,13 @@ defmodule UnionTypespec.MixProject do
         "test --warnings-as-errors",
         "credo"
       ]
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ~w(CHANGELOG.md README.md),
+      main: "readme"
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule UnionTypespec.MixProject do
       deps: deps(),
       aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
+      elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: [
         check: :test,
         coveralls: :test,
@@ -49,6 +50,9 @@ defmodule UnionTypespec.MixProject do
       {:ex_doc, "~> 0.27", only: :dev, runtime: false}
     ]
   end
+
+  defp elixirc_paths(:test), do: ~w(lib test/support)
+  defp elixirc_paths(_env), do: ~w(lib)
 
   # Aliases are shortcuts or tasks specific to the current project.
   # For example, to install project dependencies and perform other setup tasks, run:

--- a/test/support/some_module.ex
+++ b/test/support/some_module.ex
@@ -1,5 +1,6 @@
-defmodule SomeModule do
+defmodule UnionTypespec.Test.SampleModule do
   @moduledoc false
+
   import UnionTypespec, only: [union_type: 1, union_typep: 1]
 
   @statuses [:read, :unread, :deleted]

--- a/test/support/some_module.ex
+++ b/test/support/some_module.ex
@@ -1,6 +1,6 @@
-defmodule Test.ModuleTest do
+defmodule SomeModule do
   @moduledoc false
-  import UnionTypespec, only: [union_type: 1]
+  import UnionTypespec, only: [union_type: 1, union_typep: 1]
 
   @statuses [:read, :unread, :deleted]
   union_type status :: @statuses
@@ -8,10 +8,26 @@ defmodule Test.ModuleTest do
   @permissions [:view, :edit, :admin]
   @type permission :: unquote(UnionTypespec.union_type_ast(@permissions))
 
+  @roles [:user, :admin]
+  union_typep role :: @roles
+
   @spec get_permission() :: permission()
   def get_permission do
     # Test the error case by returning something else (like :ok)
     hd(@permissions)
+  end
+
+  @spec authorized?(map()) :: boolean()
+  def authorized?(_user) do
+    # Calling the private function
+    get_role()
+    true
+  end
+
+  @spec get_role() :: role()
+  defp get_role do
+    # Test the error case by returning something else (like :ok)
+    hd(@roles)
   end
 
   @spec get_status() :: status()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/test/union_typespec_test.exs
+++ b/test/union_typespec_test.exs
@@ -1,0 +1,32 @@
+defmodule UnionTypespecTest do
+  use ExUnit.Case, async: true
+
+  alias UnionTypespec.Test.SampleModule
+
+  describe "union_type/1" do
+    test "creates a valid @type from list" do
+      assert fetch!(:type, :status) == "status() :: :read | :unread | :deleted"
+    end
+  end
+
+  describe "union_type_ast/1" do
+    test "when unquoted in a @type, creates valid value of type" do
+      assert fetch!(:type, :permission) == "permission() :: :view | :edit | :admin"
+    end
+  end
+
+  describe "union_typep/1" do
+    test "creates a valid @typep from list" do
+      assert fetch!(:typep, :role) == "role() :: :user | :admin"
+    end
+  end
+
+  defp fetch!(type_of_type, type_name) do
+    assert {:ok, types} = Code.Typespec.fetch_types(SampleModule)
+    assert {^type_of_type, type} = Enum.find(types, fn {_, {name, _, _}} -> name == type_name end)
+
+    type
+    |> Code.Typespec.type_to_quoted()
+    |> Macro.to_string()
+  end
+end


### PR DESCRIPTION
Hi there!

This PR main objective is to include the macro for private types, named `union_typep/1`.

It also applies some QoL changes to help you package it on Hex:

- Created a CHANGELOG.md to keep track of changes
- Included both README.md and CHANGELOG.md in the docs
- Set the initial version for the module and the functions.
- Moved the test module to `test` folder. This will avoid to package it. It is still compiled during tests due to the `elixirc_paths` changes.
- Create single test cases for each function/macro available in the module.