### PR TITLE
Prepare to release v0.04 and publish to Hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ are one of a fixed set of options.
 
 There are two ways to use it:
 
-1. The `union_type` macro, which replaces a normal `@type` annotation with a nice,
+1. The `union_type` and `union_typep` macros, which replaces normal `@type`/`@typep` annotations with a nice,
    concise macro version of the type definition.
 2. `UnionTypespec.union_type_ast/1`, which produces an AST you can `unquote` within
    the usual `@type` definition.
@@ -32,16 +32,12 @@ end
 
 ## Installation
 
-We have not yet published the package to Hex, because it's not (yet?) clear
-that it's valuable to anyone else. Until we do, you can still install it by
-adding the following to your `mix.exs` and running `$ mix deps.get`:
+You can install the package from Hex by adding this to your `mix.exs` file's dependencies:
 
 ```elixir
 def deps do
   [
-    {:union_typespec, git: "https://github.com/felt/union_typespec.git", tag: "v0.0.3", runtime: false},
+    {:union_typespec, "~> 0.0.4", runtime: false},
   ]
 end
 ```
-
-And if you do find it useful, we'd love to hear about it!

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule UnionTypespec.MixProject do
   def project do
     [
       app: :union_typespec,
-      version: "0.0.3",
+      version: "0.0.4",
       elixir: "~> 1.12",
       package: package(),
       source_url: "https://github.com/felt/union_typespec",


### PR DESCRIPTION
This is a version bump to take the `union_typep` macro and update the docs so we can publish the package on Hex.

Resolves #37 